### PR TITLE
Limit the warning to only Collections and Map; limit the warning only to constructors that don't have generic parameters.

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Tiny.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Tiny.java
@@ -32,9 +32,11 @@ import com.sun.source.tree.LineMap;
 import com.sun.source.tree.LiteralTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.SwitchTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
+import com.sun.source.tree.VariableTree;
 import com.sun.source.tree.WhileLoopTree;
 import com.sun.source.util.SourcePositions;
 import com.sun.source.util.TreePath;
@@ -51,6 +53,8 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -196,13 +200,36 @@ public class Tiny {
     }
 
     @Hint(displayName = "#DN_org.netbeans.modules.java.hints.bugs.Tiny.varTypeDiamondOperator", description = "#DESC_org.netbeans.modules.java.hints.bugs.Tiny.varTypeDiamondOperator", category="bugs", suppressWarnings="AllowVarTypeDiamondOperator")
-    @TriggerPattern(value="$mods$ $varType $name = new $type<>($args$)")
+    @TriggerPatterns({
+        @TriggerPattern(value="$mods$ $varType $name = new $type<>($args$)", constraints=@ConstraintVariableType(variable="$type", type="java.util.Collection")),
+        @TriggerPattern(value="$mods$ $varType $name = new $type<>($args$)", constraints=@ConstraintVariableType(variable="$type", type="java.util.Map"))
+    })
     public static ErrorDescription varTypeDiamondOperator(HintContext ctx) {
         TreePath path = ctx.getPath();
         Boolean isVarUsed = ctx.getInfo().getTreeUtilities().isVarType(path);
         if(!isVarUsed){
             return null;
         }
+
+        VariableTree vt = (VariableTree) ctx.getPath().getLeaf();
+        NewClassTree nct = (NewClassTree) vt.getInitializer();
+        Element constructorCand = ctx.getInfo().getTrees().getElement(new TreePath(ctx.getPath(), nct));
+
+        if (constructorCand.getKind() != ElementKind.CONSTRUCTOR) {
+            return null;
+        }
+
+        ExecutableElement constructor = (ExecutableElement) constructorCand;
+
+        for (VariableElement param : constructor.getParameters()) {
+            if (param.asType().getKind() == TypeKind.DECLARED) {
+                DeclaredType dt = (DeclaredType) param.asType();
+                if (!dt.getTypeArguments().isEmpty()) {
+                    return null;
+                }
+            }
+        }
+
         String displayName = NbBundle.getMessage(Tiny.class, "ERR_varTypeDiamondOperator");
 
         return ErrorDescriptionFactory.forTree(ctx, path, displayName);

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/TinyTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/TinyTest.java
@@ -382,6 +382,19 @@ public class TinyTest extends NbTestCase {
                 .assertWarnings("3:8-3:42:verifier:ERR_varTypeDiamondOperator");
     }
     
+    public void testVarUsageWithoutExplicitType3() throws Exception {
+        HintTest.create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    public void test() {\n" +
+                       "        var v = new java.util.HashMap<>();\n" +
+                       "    }\n" +
+                       "}\n")
+                .sourceLevel("11")
+                .run(Tiny.class)
+                .assertWarnings("3:8-3:42:verifier:ERR_varTypeDiamondOperator");
+    }
+    
     public void testVarUsageWithExplicitType() throws Exception {
         HintTest.create()
                 .input("package test;\n" +
@@ -432,6 +445,32 @@ public class TinyTest extends NbTestCase {
                 .assertWarnings();
     }
     
+    public void testVarUsageSensibleTypeInferred1() throws Exception {
+        HintTest.create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    public void test(java.util.Set<String> input) {\n" +
+                       "        var v = new java.util.HashSet<>(input);\n" +
+                       "    }\n" +
+                       "}\n")
+                .sourceLevel("11")
+                .run(Tiny.class)
+                .assertWarnings();
+    }
+
+    public void testVarUsageSensibleTypeInferred2() throws Exception {
+        HintTest.create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    public void test(java.util.Map<String, String> input) {\n" +
+                       "        var v = new java.util.HashMap<>(input);\n" +
+                       "    }\n" +
+                       "}\n")
+                .sourceLevel("11")
+                .run(Tiny.class)
+                .assertWarnings();
+    }
+
     private static Map<String, String> alterSettings(String... settings) throws Exception {
         //XXX: hack, need to initialize the HintTest's lookup before setting the
         //formatting preferences


### PR DESCRIPTION
When we were making the hint more generic, I think I/we went too far. I am sorry for that. This patch limits the warning only to Collections/Maps, and only to constructors that don't have generic parameters - constructors with generic parameters are, I think, quite likely to infer something better than `Object`.
