### PR TITLE
Make maven.config settings parsing testable and add unit tests; support user settings override

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
@@ -118,6 +118,7 @@ import org.netbeans.modules.csl.api.IndexSearcher;
 import org.netbeans.modules.editor.indent.spi.CodeStylePreferences;
 import org.netbeans.modules.gsf.testrunner.ui.api.TestMethodController;
 import org.netbeans.modules.gsf.testrunner.ui.api.TestMethodFinder;
+import org.netbeans.modules.maven.options.MavenSettings;
 import org.netbeans.modules.java.hints.spi.preview.PreviewEnabler;
 import org.netbeans.modules.java.hints.spi.preview.PreviewEnabler.Factory;
 import org.netbeans.modules.java.lsp.server.LspServerState;
@@ -1422,6 +1423,9 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
 
         BiConsumer<String, JsonElement> projectJdkHomeListener = (config, newValue)
                 -> ((TextDocumentServiceImpl) server.getTextDocumentService()).updateProjectJDKHome(newValue.getAsJsonPrimitive());
+
+        BiConsumer<String, JsonElement> mavenSettingsListener = (config, newValue)
+                -> updateMavenSettings(newValue != null && newValue.isJsonObject() ? newValue.getAsJsonObject() : null);
         
         
         
@@ -1429,6 +1433,7 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
         confManager.registerConfigChangeListener(fullConfigPrefix + "project.jdkhome", projectJdkHomeListener);
         confManager.registerConfigChangeListener(fullConfigPrefix + "format", formatPrefsListener);
         confManager.registerConfigChangeListener(fullConfigPrefix + "java.imports", importPrefsListener);
+        confManager.registerConfigChangeListener(fullConfigPrefix + "maven", mavenSettingsListener);
         confManager.registerConfigChangeListener(fullAltConfigPrefix + "runConfig", getRunConfigChangeListener());
     }
 
@@ -1459,6 +1464,17 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
             prefs.putBoolean("allowConvertToStaticStarImport", true);
             prefs.putInt("countForUsingStaticStarImport", configuration.getAsJsonPrimitive("countForUsingStaticStarImport").getAsInt());
         }
+    }
+
+    void updateMavenSettings(JsonObject configuration) {
+        String settingsPath = null;
+        if (configuration != null) {
+            JsonElement pathElement = configuration.get("settingsPath");
+            if (pathElement != null && pathElement.isJsonPrimitive()) {
+                settingsPath = pathElement.getAsString();
+            }
+        }
+        MavenSettings.getDefault().setUserSettingsFilePath(settingsPath);
     }
 
     @NbBundle.Messages({

--- a/java/maven.embedder/src/org/netbeans/modules/maven/embedder/EmbedderFactory.java
+++ b/java/maven.embedder/src/org/netbeans/modules/maven/embedder/EmbedderFactory.java
@@ -60,6 +60,7 @@ public final class EmbedderFactory {
     
     //same prop constant in MavenSettings.java
     static final String PROP_DEFAULT_OPTIONS = "defaultOptions"; 
+    public static final String PROP_USER_SETTINGS_OVERRIDE = "netbeans.maven.userSettings"; // NOI18N
     private static final Set<String> forbidden = Set.of(
         "netbeans.logger.console", //NOI18N
         "java.util.logging.config.class", //NOI18N

--- a/java/maven.embedder/src/org/netbeans/modules/maven/embedder/MavenEmbedder.java
+++ b/java/maven.embedder/src/org/netbeans/modules/maven/embedder/MavenEmbedder.java
@@ -200,7 +200,9 @@ public final class MavenEmbedder {
             return testSettings; // could instead make public void setSettings(Settings settingsOverride)
         }
         File settingsXml = embedderConfiguration.getSettingsXml();
-        long newSettingsTimestamp = settingsXml.hashCode() ^ settingsXml.lastModified() ^ SettingsXmlConfigurationProcessor.DEFAULT_USER_SETTINGS_FILE.lastModified();
+        File userSettings = getEffectiveUserSettingsFile();
+        long newSettingsTimestamp = settingsXml.hashCode() ^ settingsXml.lastModified()
+                ^ (userSettings != null ? userSettings.hashCode() ^ userSettings.lastModified() : 0L);
         // could be included but currently constant: hashCode() of those files; getSystemProperties.hashCode()
         if (settings != null && settingsTimestamp == newSettingsTimestamp) {
             LOG.log(Level.FINER, "settings.xml cache hit for {0}", this);
@@ -209,7 +211,9 @@ public final class MavenEmbedder {
         LOG.log(Level.FINE, "settings.xml cache miss for {0}", this);
         SettingsBuildingRequest req = new DefaultSettingsBuildingRequest();
         req.setGlobalSettingsFile(settingsXml);
-        req.setUserSettingsFile(SettingsXmlConfigurationProcessor.DEFAULT_USER_SETTINGS_FILE);
+        if (userSettings != null && userSettings.exists()) {
+            req.setUserSettingsFile(userSettings);
+        }
         req.setSystemProperties(getSystemProperties());
         req.setUserProperties(embedderConfiguration.getUserProperties());
         try {
@@ -586,8 +590,9 @@ public final class MavenEmbedder {
         if (settingsXml !=null && settingsXml.exists()) {
             req.setGlobalSettingsFile(settingsXml);
         }
-        if (SettingsXmlConfigurationProcessor.DEFAULT_USER_SETTINGS_FILE != null && SettingsXmlConfigurationProcessor.DEFAULT_USER_SETTINGS_FILE.exists()) {
-          req.setUserSettingsFile(SettingsXmlConfigurationProcessor.DEFAULT_USER_SETTINGS_FILE);
+        File userSettings = getEffectiveUserSettingsFile();
+        if (userSettings != null && userSettings.exists()) {
+          req.setUserSettingsFile(userSettings);
         }
         
         req.setSystemProperties(getSystemProperties());
@@ -607,6 +612,27 @@ public final class MavenEmbedder {
         req.setRepositoryCache(new NbRepositoryCache());
 
         return req;
+    }
+
+    private File getEffectiveUserSettingsFile() {
+        File override = getUserSettingsFileOverride();
+        if (override != null) {
+            return override;
+        }
+        return SettingsXmlConfigurationProcessor.DEFAULT_USER_SETTINGS_FILE;
+    }
+
+    private File getUserSettingsFileOverride() {
+        String settingsPath = System.getProperty(EmbedderFactory.PROP_USER_SETTINGS_OVERRIDE);
+        if (settingsPath == null) {
+            return null;
+        }
+        String trimmed = settingsPath.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        File candidate = FileUtil.normalizeFile(new File(trimmed));
+        return candidate.isFile() && candidate.canRead() ? candidate : null;
     }
     
     /**

--- a/java/maven.embedder/test/unit/src/org/netbeans/modules/maven/embedder/EmbedderFactoryTest.java
+++ b/java/maven.embedder/test/unit/src/org/netbeans/modules/maven/embedder/EmbedderFactoryTest.java
@@ -36,6 +36,7 @@ import org.netbeans.junit.NbTestCase;
 import org.openide.util.NbPreferences;
 import org.openide.util.test.MockLookup;
 import org.openide.util.test.TestFileUtils;
+import org.openide.filesystems.FileUtil;
 
 public class EmbedderFactoryTest extends NbTestCase {
     
@@ -167,6 +168,20 @@ public class EmbedderFactoryTest extends NbTestCase {
         assertEquals(System.getProperty("java.home"), p.getProperty("java.home"));
         assertEquals(System.getenv("PATH"), p.getProperty("env.PATH"));
         // XXX perhaps -Dkey=value (and -Dkey) should be honored in "Global Execution Options"?
+    }
+
+    public void testUserSettingsOverride() throws Exception {
+        File settings = TestFileUtils.writeFile(new File(getWorkDir(), "settings.xml"),
+                "<settings xmlns='http://maven.apache.org/SETTINGS/1.0.0'/>");
+        System.setProperty(EmbedderFactory.PROP_USER_SETTINGS_OVERRIDE, settings.getAbsolutePath());
+        try {
+            MavenEmbedder embedder = EmbedderFactory.getProjectEmbedder();
+            MavenExecutionRequest req = embedder.createMavenExecutionRequest();
+            assertEquals(FileUtil.normalizeFile(settings), req.getUserSettingsFile());
+        } finally {
+            System.clearProperty(EmbedderFactory.PROP_USER_SETTINGS_OVERRIDE);
+            EmbedderFactory.resetCachedEmbedders();
+        }
     }
     
     public void testCustomProperties() throws Exception {

--- a/java/maven/src/org/netbeans/modules/maven/modelcache/MavenProjectCache.java
+++ b/java/maven/src/org/netbeans/modules/maven/modelcache/MavenProjectCache.java
@@ -353,10 +353,12 @@ public final class MavenProjectCache {
         
         try {
             List<String> mavenConfigOpts = Collections.emptyList();
+            FileObject mavenConfigRoot = null;
             for (FileObject root = projectDir; root != null; root = root.getParent()) {
                 FileObject mavenConfig = root.getFileObject(".mvn/maven.config");
                 if (mavenConfig != null && mavenConfig.isData()) {
                     mavenConfigOpts = Arrays.asList(mavenConfig.asText().split("\\s+"));
+                    mavenConfigRoot = root;
                     LOG.log(Level.FINE, "Found maven config options: {0}", mavenConfigOpts);
                     break;
                 }
@@ -365,6 +367,7 @@ public final class MavenProjectCache {
             req.addActiveProfiles(active.getActivatedProfiles());
             BiConsumer<String, String> addActiveProfiles = (opt, prefix) -> req.addActiveProfiles(Arrays.asList(opt.substring(prefix.length()).split(",")));
             Iterator<String> optIt = mavenConfigOpts.iterator();
+            File settingsFile = findSettingsFile(mavenConfigRoot, mavenConfigOpts);
             while (optIt.hasNext()) {
                 String opt = optIt.next();
                 // Could try to write/integrate a more general option parser here,
@@ -376,6 +379,9 @@ public final class MavenProjectCache {
                 } else if (opt.startsWith("--activate-profiles=")) {
                     addActiveProfiles.accept(opt, "--activate-profiles=");
                 }
+            }
+            if (settingsFile != null) {
+                req.setUserSettingsFile(settingsFile);
             }
             if (runConf != null) {
                 req.addActiveProfiles(runConf.getActivatedProfiles());
@@ -528,6 +534,41 @@ public final class MavenProjectCache {
             props.putAll(activeConfiguration);
         }
         return props;
+    }
+
+    static File findSettingsFile(FileObject mavenConfigRoot, List<String> mavenConfigOpts) {
+        if (mavenConfigOpts == null || mavenConfigOpts.isEmpty()) {
+            return null;
+        }
+        Iterator<String> optIt = mavenConfigOpts.iterator();
+        while (optIt.hasNext()) {
+            String opt = optIt.next();
+            if (opt.equals("-s") || opt.equals("--settings")) {
+                if (optIt.hasNext()) {
+                    return resolveSettingsFile(mavenConfigRoot, optIt.next());
+                }
+            } else if (opt.startsWith("-s") && opt.length() > 2) {
+                String settingsPath = opt.startsWith("-s=") ? opt.substring(3) : opt.substring(2);
+                return resolveSettingsFile(mavenConfigRoot, settingsPath);
+            } else if (opt.startsWith("--settings=")) {
+                return resolveSettingsFile(mavenConfigRoot, opt.substring("--settings=".length()));
+            }
+        }
+        return null;
+    }
+
+    private static File resolveSettingsFile(FileObject mavenConfigRoot, String settingsPath) {
+        if (settingsPath == null || settingsPath.isEmpty()) {
+            return null;
+        }
+        File resolved = new File(settingsPath);
+        if (!resolved.isAbsolute() && mavenConfigRoot != null) {
+            File rootFile = FileUtil.toFile(mavenConfigRoot);
+            if (rootFile != null) {
+                resolved = new File(rootFile, settingsPath);
+            }
+        }
+        return resolved;
     }
     
     

--- a/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
@@ -116,7 +116,10 @@ public final class MavenSettings  {
     }
 
     public void setUserSettingsFilePath(@CheckForNull String settingsPath) {
-        String normalized = settingsPath != null && !settingsPath.isBlank() ? settingsPath.trim() : null;
+        String normalized = settingsPath != null ? settingsPath.trim() : null;
+        if (normalized != null && normalized.isEmpty()) {
+            normalized = null;
+        }
         String oldValue = System.getProperty(EmbedderFactory.PROP_USER_SETTINGS_OVERRIDE);
         if (normalized != null) {
             System.setProperty(EmbedderFactory.PROP_USER_SETTINGS_OVERRIDE, normalized);

--- a/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.Objects;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 import java.util.regex.Pattern;
@@ -112,6 +113,19 @@ public final class MavenSettings  {
 
     public static MavenSettings getDefault() {
         return INSTANCE;
+    }
+
+    public void setUserSettingsFilePath(@CheckForNull String settingsPath) {
+        String normalized = settingsPath != null && !settingsPath.isBlank() ? settingsPath.trim() : null;
+        String oldValue = System.getProperty(EmbedderFactory.PROP_USER_SETTINGS_OVERRIDE);
+        if (normalized != null) {
+            System.setProperty(EmbedderFactory.PROP_USER_SETTINGS_OVERRIDE, normalized);
+        } else {
+            System.clearProperty(EmbedderFactory.PROP_USER_SETTINGS_OVERRIDE);
+        }
+        if (!Objects.equals(oldValue, normalized)) {
+            EmbedderFactory.resetCachedEmbedders();
+        }
     }
 
     public boolean isInteractive() {

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/modelcache/MavenProjectCacheTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/modelcache/MavenProjectCacheTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.modelcache;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import org.netbeans.junit.NbTestCase;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.test.TestFileUtils;
+
+public class MavenProjectCacheTest extends NbTestCase {
+
+    public MavenProjectCacheTest(String name) {
+        super(name);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        clearWorkDir();
+    }
+
+    public void testFindSettingsFileRelative() throws Exception {
+        File root = getWorkDir();
+        File settings = new File(new File(root, "alt"), "settings.xml");
+        TestFileUtils.writeFile(settings, "<settings/>");
+        List<String> options = Arrays.asList("-s", "alt/settings.xml");
+        FileObject rootFo = FileUtil.toFileObject(root);
+        assertNotNull(rootFo);
+        File resolved = MavenProjectCache.findSettingsFile(rootFo, options);
+        assertEquals(FileUtil.normalizeFile(settings), resolved);
+    }
+
+    public void testFindSettingsFileAbsolute() throws Exception {
+        File root = getWorkDir();
+        File settings = new File(root, "settings.xml");
+        TestFileUtils.writeFile(settings, "<settings/>");
+        List<String> options = Arrays.asList("--settings=" + settings.getAbsolutePath());
+        FileObject rootFo = FileUtil.toFileObject(root);
+        assertNotNull(rootFo);
+        File resolved = MavenProjectCache.findSettingsFile(rootFo, options);
+        assertEquals(FileUtil.normalizeFile(settings), resolved);
+    }
+
+    public void testFindSettingsFileInlineShortOption() throws Exception {
+        File root = getWorkDir();
+        File settings = new File(root, "settings.xml");
+        TestFileUtils.writeFile(settings, "<settings/>");
+        List<String> options = Arrays.asList("-s=" + settings.getAbsolutePath());
+        FileObject rootFo = FileUtil.toFileObject(root);
+        assertNotNull(rootFo);
+        File resolved = MavenProjectCache.findSettingsFile(rootFo, options);
+        assertEquals(FileUtil.normalizeFile(settings), resolved);
+    }
+}


### PR DESCRIPTION
### Motivation

- Make parsing of `.mvn/maven.config` options testable and robust so `settings.xml` references can be resolved reliably. 
- Allow programmatic overrides of the Maven user settings file and ensure embedder caching accounts for that override. 

### Description

- Refactored `.mvn/maven.config` parsing by extracting `MavenProjectCache.findSettingsFile` and `resolveSettingsFile` and used them to set the request user settings file when loading projects. 
- Added `MavenSettings.setUserSettingsFilePath` to expose a programmatic way to set the user settings override and to reset cached embedders when changed. 
- Implemented support for a user-settings override in `EmbedderFactory` via the `EmbedderFactory.PROP_USER_SETTINGS_OVERRIDE` system property and added `getEffectiveUserSettingsFile` / `getUserSettingsFileOverride` helpers so `createMavenExecutionRequest` and settings-building honor the override and the settings cache key. 
- Wired a configuration listener in `WorkspaceServiceImpl` to accept Maven settings updates and call `MavenSettings.getDefault().setUserSettingsFilePath(...)`. 
- Added unit tests in `java/maven/test/unit/src/org/netbeans/modules/maven/modelcache/MavenProjectCacheTest.java` covering relative, absolute, and inline `-s`/`--settings` forms, and added `testUserSettingsOverride` to `EmbedderFactoryTest` to verify the system-property override behavior. 

### Testing

- Added unit tests: `MavenProjectCacheTest.testFindSettingsFileRelative`, `testFindSettingsFileAbsolute`, `testFindSettingsFileInlineShortOption`, and `EmbedderFactoryTest.testUserSettingsOverride`; these tests were added to the repository but were not executed in this rollout. 
- No automated test runs were performed as part of this change (tests were created and committed only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989cecc71cc83308111d11d1e51285d)